### PR TITLE
Remove type hint for AbstractTrash.getSize()

### DIFF
--- a/apps/files_trashbin/lib/Sabre/AbstractTrash.php
+++ b/apps/files_trashbin/lib/Sabre/AbstractTrash.php
@@ -55,7 +55,9 @@ abstract class AbstractTrash implements ITrash {
 		return $this->data;
 	}
 
-	public function getSize(): int {
+	// Removal of return type is intentional as int is not large enough on 32 bit systems
+	// see https://github.com/nextcloud/server/issues/13160
+	public function getSize() {
 		return $this->data->getSize();
 	}
 


### PR DESCRIPTION
Int is not large enough on 32 bit systems to represent the size of a large trash. This leads to errors when displaying the trash in the web.

See https://github.com/nextcloud/server/issues/13160